### PR TITLE
Swap sqlalchemy.utils unquote_plus for urllib.parse unquote_plus in progress_sa/pyodbc.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Disclaimer
-I am fine tuning this Progress Openedge SQLalchemy dialect for use in a meltano based data infrastructure imporvement at my organization.
+I am fine tuning this Progress Openedge SQLalchemy dialect for use in a meltano based data infrastructure improvement at my organization.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Disclaimer
+I am fine tuning this Progress Openedge SQLalchemy dialect for use in a meltano based data infrastructure imporvement at my organization.
+
+
+
+
 # SQLAlchemy dialect for Progress OpenEdge
 
 An adaption of [this work](https://github.com/dholth/progress_sa) for Python3 and Progress OpenEdge 11.7

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ An adaption of [this work](https://github.com/dholth/progress_sa) for Python3 an
 $ cd progress_sa
 $ python setup.py install
 ```
+## DRIVER_NAME env variable
+Due to variation in driver names, create an environment variable called PROGRESS_OE_DRIVER_NAME with your particular driver name and the driver will pull it in and use it. 
 
 ## Usage
 

--- a/progress_sa/base.py
+++ b/progress_sa/base.py
@@ -197,6 +197,11 @@ class ProgressDialect(default.DefaultDialect):
     
     def _get_raw_cursor(self, connection):
         return connection.engine.raw_connection().cursor()
+    
+    def get_schema_names(self, connection, **kw):
+        cursor = self._get_raw_cursor(connection)
+        schemas = cursor.execute('select distinct owner from sysprogress.SYSTABLES')
+        return [row[0] for row in schemas]
 
     def get_table_names(self, connection, schema):
         cursor = self._get_raw_cursor(connection)

--- a/progress_sa/base.py
+++ b/progress_sa/base.py
@@ -96,6 +96,10 @@ ischema_names = {
         'timestamp_timezone':TIMESTAMP,
         'varbinary':VARCHAR,
         'varchar':VARCHAR,
+        'lvarbinary':VARCHAR,
+        'varbina':VARCHAR,
+        'lvarchar':VARCHAR,
+        'decimal':FLOAT,
 }
 
 class ProgressExecutionContext(default.DefaultExecutionContext):
@@ -227,7 +231,7 @@ class ProgressDialect(default.DefaultDialect):
 
             type_name = column[index['type_name']]
             column_size = column[index['column_size']]
-            coltype = ischema_names[type_name](column_size)
+            coltype = ischema_names[type_name]()
 
             columns.append(dict(name=name, type=coltype,
                 nullable=nullable, default=default,

--- a/progress_sa/base.py
+++ b/progress_sa/base.py
@@ -84,7 +84,7 @@ ischema_names = {
         'bigint':BIGINT,
         'bit':BOOLEAN,
         'character':CHAR,
-        'date':DATE,
+        'date':TIMESTAMP,
         'float':FLOAT, # double precision. Also FLOAT(8) in SQL.
         'integer':INTEGER,
         'numeric':NUMERIC,

--- a/progress_sa/base.py
+++ b/progress_sa/base.py
@@ -203,7 +203,7 @@ class ProgressDialect(default.DefaultDialect):
         schemas = cursor.execute('select distinct owner from sysprogress.SYSTABLES')
         return [row[0] for row in schemas]
 
-    def get_table_names(self, connection, schema):
+    def get_table_names(self, connection, schema, **kw):
         cursor = self._get_raw_cursor(connection)
         s = cursor.tables(schema=schema or '')
         return [row.table_name for row in s]

--- a/progress_sa/base.py
+++ b/progress_sa/base.py
@@ -207,6 +207,7 @@ class ProgressDialect(default.DefaultDialect):
         cursor = self._get_raw_cursor(connection)
         s = cursor.tables(schema=schema or '')
         return [row.table_name for row in s]
+    
 
     def has_table(self, connection, tablename, schema=None):
         cursor = self._get_raw_cursor(connection)
@@ -242,6 +243,25 @@ class ProgressDialect(default.DefaultDialect):
     def get_foreign_keys(self, *args, **kw):
         # does not seem to be implemented in the database.
         return []
+    
+    def get_pk_constraint(self, connection, tablename, schema, **kw):
+        pkeys = []
+        cursor = self._get_raw_cursor(connection)
+        c = cursor.execute('select * from SYSPROGRESS.SYS_TBL_CONSTRS')
+        constraint_name = None
+
+        for row in c.fetchall():
+            if "PRIMARY" in row[1]:
+                pkeys.append(row[4])
+                if constraint_name is None:
+                    constraint_name = row[0]
+        if pkeys:
+            return {
+                "constrained_columns": pkeys,
+                "name": constraint_name,
+            }
+
+
 
     def get_indexes(self, connection, table_name, schema=None, **kw):
         # implemented in the database, not terribly useful.

--- a/progress_sa/pyodbc.py
+++ b/progress_sa/pyodbc.py
@@ -1,6 +1,7 @@
 from progress_sa.base import ProgressDialect, ProgressExecutionContext
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from sqlalchemy import util
+from urllib.parse import unquote_plus
 import sys
 
 
@@ -30,7 +31,7 @@ class Progress_pyodbc(PyODBCConnector, ProgressDialect):
                 connect_args[param] = util.asbool(keys.pop(param))
 
         if "odbc_connect" in keys:
-            connectors = [util.unquote_plus(keys.pop("odbc_connect"))]
+            connectors = [unquote_plus(keys.pop("odbc_connect"))]
         else:
 
             def check_quote(token):

--- a/progress_sa/pyodbc.py
+++ b/progress_sa/pyodbc.py
@@ -3,6 +3,7 @@ from sqlalchemy.connectors.pyodbc import PyODBCConnector
 from sqlalchemy import util
 from urllib.parse import unquote_plus
 import sys
+import os
 
 
 class ProgressExecutionContext_pyodbc(ProgressExecutionContext):
@@ -11,7 +12,7 @@ class ProgressExecutionContext_pyodbc(ProgressExecutionContext):
 
 class Progress_pyodbc(PyODBCConnector, ProgressDialect):
 #    pyodbc_driver_name = 'Progress OpenEdge Wire Protocol'
-    pyodbc_driver_name = 'DataDirect 7.1 Progress OpenEdge Wire Protocol'
+    pyodbc_driver_name = os.environ.get("PROGRESS_OE_DRIVER_NAME")
     execution_ctx_cls = ProgressExecutionContext_pyodbc
     def __init__(self, **kwargs):
         super(Progress_pyodbc, self).__init__(**kwargs)


### PR DESCRIPTION
I noticed in my testing that using this dialect with SQLAlchemy when it is above version 2.0 does not work as the unquote_plus method is no longer supported. I have changed the file to utilize the urllibs.parse version of unquote_plus, which should be future proof as it is part of the standard library.

